### PR TITLE
OpenFAN Micro: Pro pack - LED & 12V switches, availability, stall, temp curve + smoothing, calibration (v0.3.1-beta.2)Add files via upload

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,215 @@
+"""Setup & services for OpenFAN Micro (pro pack with temp smoothing)."""
+from __future__ import annotations
+import logging, asyncio, time
+from typing import Any
+from collections import deque
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.event import async_track_state_change_event
+
+from .const import DOMAIN
+from ._device import Device
+from .options_flow import OptionsFlowHandler
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS: list[Platform] = [Platform.FAN, Platform.SENSOR, Platform.SWITCH, Platform.BINARY_SENSOR]
+
+
+async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    host = entry.data.get("host"); name = entry.data.get("name"); mac = entry.data.get("mac")
+    if not host:
+        _LOGGER.error("%s: missing 'host' in config entry", DOMAIN)
+        return False
+
+    dev = Device(hass, host, name, mac=mac)
+
+    # --- apply options to API/coordinator ---
+    opts = entry.options or {}
+    dev.api._poll_interval      = int(opts.get("poll_interval", 5))
+    dev.api._min_pwm            = int(opts.get("min_pwm", 0))
+    dev.api._failure_threshold  = int(opts.get("failure_threshold", 3))
+    dev.api._stall_consecutive  = int(opts.get("stall_consecutive", 3))
+
+    await dev.async_first_refresh()
+    entry.runtime_data = dev
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # --- temperature controller: piecewise-linear + smoothing (gated by calibration) ---
+    temp_entity = (opts.get("temp_entity") or "").strip()
+    temp_curve  = (opts.get("temp_curve") or "").strip()
+    integrate_s = int(opts.get("temp_integrate_seconds", 30))
+    min_interval_s = int(opts.get("temp_update_min_interval", 10))
+    deadband = int(opts.get("temp_deadband_pct", 3))
+
+    # buffer of (timestamp_monotonic, temp_value)
+    temp_buf: deque[tuple[float, float]] = deque(maxlen=512)
+    last_set_ts: float = 0.0
+    last_set_pwm: int | None = None
+
+    def parse_curve(txt: str):
+        pts = []
+        for part in [p.strip() for p in txt.split(",") if p.strip()]:
+            if "=" in part:
+                t, pct = part.split("=", 1)
+                try:
+                    pts.append((float(t.strip()), max(0, min(100, int(pct.strip())))))
+                except Exception:
+                    continue
+        pts.sort(key=lambda x: x[0])
+        return pts
+
+    def averaged_temp(now: float) -> float | None:
+        # prune old samples
+        cutoff = now - max(5, integrate_s)
+        while temp_buf and temp_buf[0][0] < cutoff:
+            temp_buf.popleft()
+        if not temp_buf:
+            return None
+        # simple arithmetic mean over window
+        return sum(val for _, val in temp_buf) / len(temp_buf)
+
+    async def apply_from_temp(raw_temp: float):
+        nonlocal last_set_ts, last_set_pwm
+        # Gate by calibration
+        min_cal_ok = bool(entry.options.get("min_pwm_calibrated", False)) and int(entry.options.get("min_pwm", 0)) > 0
+        if not min_cal_ok:
+            _LOGGER.debug("OpenFAN Micro %s: temp control ignored (not calibrated yet)", host)
+            return
+
+        pts = parse_curve(entry.options.get("temp_curve", temp_curve))
+        if not pts:
+            return
+
+        now = time.monotonic()
+        temp_avg = averaged_temp(now)
+        if temp_avg is None:
+            # not enough samples yet
+            return
+
+        # piecewise linear interpolation on averaged temperature
+        temp = temp_avg
+        if temp <= pts[0][0]:
+            target = pts[0][1]
+        elif temp >= pts[-1][0]:
+            target = pts[-1][1]
+        else:
+            target = pts[0][1]
+            for (t1, p1), (t2, p2) in zip(pts, pts[1:]):
+                if t1 <= temp <= t2:
+                    if t2 == t1:
+                        target = max(p1, p2)
+                    else:
+                        ratio = (temp - t1) / (t2 - t1)
+                        target = int(round(p1 + (p2 - p1) * ratio))
+                    break
+
+        min_pwm = int(entry.options.get("min_pwm", 0))
+        # never drive below min (except allow 0 to turn off)
+        target = 0 if target == 0 else max(min_pwm, int(target))
+        target = max(0, min(100, int(target)))
+
+        # debounce & deadband against last set OR current coordinator value
+        if last_set_pwm is None:
+            cur = dev.coordinator.data.get("pwm") if dev.coordinator.data else None
+            last_set_pwm = int(cur) if isinstance(cur, int) else target
+
+        if abs(int(target) - int(last_set_pwm)) < max(0, deadband):
+            return  # within deadband
+
+        if (now - last_set_ts) < max(1, min_interval_s):
+            return  # too soon to change again
+
+        await dev.api.set_pwm(int(target))
+        await dev.coordinator.async_request_refresh()
+        last_set_pwm = int(target)
+        last_set_ts = now
+
+    unsub = None
+    if temp_entity:
+        @callback
+        def _on_temp(ev):
+            new = ev.data.get("new_state")
+            if not new or new.state in (None, "", "unknown", "unavailable"):
+                return
+            try:
+                val = float(new.state)
+            except Exception:
+                return
+            # buffer the sample and try apply with smoothing
+            temp_buf.append((time.monotonic(), val))
+            hass.async_create_task(apply_from_temp(val))
+
+        unsub = async_track_state_change_event(hass, [temp_entity], _on_temp)
+        entry.async_on_unload(unsub)
+
+    # --- services: led_set, set_voltage, calibrate_min ---
+    async def _resolve_dev(entity_id: str) -> Device | None:
+        er = await hass.helpers.entity_registry.async_get_registry()
+        ent = er.async_get(entity_id)
+        if not ent or ent.config_entry_id != entry.entry_id:
+            return None
+        return entry.runtime_data
+
+    async def svc_led_set(call):
+        dev = await _resolve_dev(call.data["entity_id"])
+        if not dev: return
+        await dev.api.led_set(bool(call.data["enabled"]))
+
+    async def svc_set_voltage(call):
+        dev = await _resolve_dev(call.data["entity_id"])
+        if not dev: return
+        volts = int(call.data["volts"])
+        await dev.api.set_voltage_12v(True if volts == 12 else False)
+
+    async def svc_calibrate_min(call):
+        dev = await _resolve_dev(call.data["entity_id"])
+        if not dev: return
+        from_pct = int(call.data.get("from_pct", 10))
+        to_pct   = int(call.data.get("to_pct", 40))
+        step     = int(call.data.get("step", 5))
+        rpm_thr  = int(call.data.get("rpm_threshold", 100))
+        margin   = int(call.data.get("margin", 5))
+
+        found = None
+        for pct in range(from_pct, to_pct + 1, step):
+            await dev.api.set_pwm(pct)
+            # wait ~1 polling interval for RPM to settle
+            await asyncio.sleep(max(1, int(dev.api._poll_interval)))
+            await dev.coordinator.async_request_refresh()
+            data = dev.coordinator.data or {}
+            rpm = int(data.get("rpm") or 0)
+            if rpm >= rpm_thr:
+                found = pct
+                break
+
+        if found is not None:
+            new_min = max(0, min(100, found + margin))
+            new_opts = dict(entry.options or {})
+            new_opts["min_pwm"] = new_min
+            new_opts["min_pwm_calibrated"] = True
+            hass.config_entries.async_update_entry(entry, options=new_opts)
+            _LOGGER.info("Calibrated min_pwm=%s for %s (marked calibrated)", new_min, entry.title)
+        else:
+            _LOGGER.warning("Calibration did not reach RPM threshold; leaving min_pwm unchanged.")
+
+    hass.services.async_register(DOMAIN, "led_set", svc_led_set)
+    hass.services.async_register(DOMAIN, "set_voltage", svc_set_voltage)
+    hass.services.async_register(DOMAIN, "calibrate_min", svc_calibrate_min)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_get_options_flow(config_entry):
+    return OptionsFlowHandler(config_entry)

--- a/_device.py
+++ b/_device.py
@@ -1,0 +1,96 @@
+"""Device wrapper for OpenFAN Micro.
+
+Exposes:
+- `api`: low-level HTTP client
+- `coordinator`: DataUpdateCoordinator for polling status
+- `device_info()`: HA device registry metadata
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.device_registry import format_mac
+
+from .api import OpenFanApi
+from .coordinator import OpenFanCoordinator
+
+try:
+    from .const import DOMAIN  # type: ignore
+except Exception:  # pragma: no cover
+    DOMAIN = "openfan_micro"
+
+
+class OpenFanDevice:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        host: str,
+        name: Optional[str] = None,
+        *,
+        mac: Optional[str] = None,
+        session=None,
+    ) -> None:
+        self.hass = hass
+        self.host = host
+        self.name = name or f"OpenFAN Micro {host}"
+
+        # Use HA's shared aiohttp session
+        if session is None:
+            from homeassistant.helpers.aiohttp_client import async_get_clientsession
+            session = async_get_clientsession(hass)
+
+        self.api = OpenFanApi(host, session)
+        self.coordinator: DataUpdateCoordinator = OpenFanCoordinator(hass, self.api)
+
+        self._fixed_data: dict[str, Any] = {
+            "host": host,
+            "name": self.name,
+            "mac": mac,
+            "model": "OpenFAN Micro",
+            "manufacturer": "Karanovic Research",
+        }
+
+    async def async_first_refresh(self) -> None:
+        """Initial status fetch (raises if network/API fails)."""
+        await self.coordinator.async_config_entry_first_refresh()
+
+    @property
+    def mac(self) -> Optional[str]:
+        """Formatted MAC address or None if not available/invalid."""
+        raw = self._fixed_data.get("mac")
+        if not raw:
+            return None
+        try:
+            return format_mac(raw)
+        except Exception:
+            return None
+
+    def device_info(self) -> dict[str, Any]:
+        """Return HA device registry information."""
+        info: dict[str, Any] = {
+            "identifiers": {(DOMAIN, self.host)},
+            "manufacturer": self._fixed_data.get("manufacturer", "Karanovic Research"),
+            "model": self._fixed_data.get("model", "OpenFAN Micro"),
+            "name": self._fixed_data.get("name", self.name),
+        }
+        m = self.mac
+        if m:
+            try:
+                from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
+                info["connections"] = {(CONNECTION_NETWORK_MAC, m)}
+            except Exception:
+                pass
+        return info
+
+    @property
+    def coordinator_data(self) -> dict[str, Any]:
+        return dict(self.coordinator.data or {})
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<OpenFanDevice host={self.host} name={self.name!r} mac={self.mac!r}>"
+
+
+# Backwards-compatible alias
+Device = OpenFanDevice

--- a/api.py
+++ b/api.py
@@ -1,0 +1,118 @@
+"""Low-level HTTP API client for OpenFAN Micro.
+
+Handles:
+- JSON parsing & logging
+- Firmware compatibility (new/legacy endpoints)
+- Status payload differences (top-level vs nested 'data')
+- LED and 5V/12V endpoints (per official docs)
+"""
+from __future__ import annotations
+from typing import Any, Tuple, Optional
+
+import logging
+import aiohttp
+import async_timeout
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class OpenFanApi:
+    def __init__(self, host: str, session: aiohttp.ClientSession) -> None:
+        self._host = host
+        self._session = session
+        # Tunables populated from options in __init__.py
+        self._poll_interval: int = 5
+        self._min_pwm: int = 0
+        self._failure_threshold: int = 3
+        self._stall_consecutive: int = 3
+
+    async def _get_json(self, path: str) -> dict:
+        """HTTP GET -> JSON dict (logs raw on error)."""
+        url = f"http://{self._host}{path}"
+        async with async_timeout.timeout(5):
+            async with self._session.get(url) as resp:
+                text = await resp.text()
+                if resp.status >= 400:
+                    _LOGGER.error("OpenFAN Micro %s HTTP %s on %s: %s",
+                                  self._host, resp.status, path, text)
+                    resp.raise_for_status()
+                try:
+                    data = await resp.json(content_type=None)
+                except Exception:
+                    _LOGGER.error("OpenFAN Micro %s non-JSON on %s: %s",
+                                  self._host, path, text)
+                    raise
+        if not isinstance(data, dict):
+            data = {}
+        _LOGGER.debug("OpenFAN Micro %s GET %s -> %s", self._host, path, data)
+        return data
+
+    # ---------- FAN PWM / STATUS ----------
+    def _parse_status_payload(self, data: dict) -> Tuple[int, int]:
+        """Accept both top-level and nested ('data') formats. Returns (rpm, pwm%)."""
+        container: dict = data or {}
+        if not ("rpm" in container or "pwm_percent" in container):
+            container = data.get("data", {}) or {}
+        rpm_raw = container.get("rpm", 0)
+        pwm_raw = container.get("pwm_percent", container.get("pwm", container.get("pwm_value", 0)))
+        try:
+            rpm = int(float(rpm_raw))
+        except Exception:
+            rpm = 0
+        try:
+            pwm = int(float(pwm_raw))
+        except Exception:
+            pwm = 0
+        return max(0, rpm), max(0, min(100, pwm))
+
+    async def set_pwm(self, value: int) -> dict[str, Any]:
+        """Set PWM 0..100; tries new (fan/0/set) and old (fan/set) endpoints."""
+        value = max(0, min(100, int(value)))
+        last_exc: Optional[Exception] = None
+        for p in (f"/api/v0/fan/0/set?value={value}", f"/api/v0/fan/set?value={value}"):
+            try:
+                data = await self._get_json(p)
+                if str(data.get("status", "")).lower() in ("ok", "success", ""):
+                    return data
+                raise RuntimeError(f"API status != ok for {p}: {data}")
+            except Exception as exc:
+                last_exc = exc
+                _LOGGER.debug("OpenFAN Micro %s: set_pwm via %s failed: %r", self._host, p, exc)
+        assert last_exc is not None
+        raise last_exc
+
+    async def get_status(self) -> Tuple[int, int]:
+        """Return (rpm, pwm_percent)."""
+        last_exc: Optional[Exception] = None
+        for p in ("/api/v0/fan/status", "/api/v0/fan/0/status"):
+            try:
+                data = await self._get_json(p)
+                if str(data.get("status", "ok")).lower() not in ("ok", "success"):
+                    raise RuntimeError(f"API status != ok for {p}: {data.get('message')}")
+                return self._parse_status_payload(data)
+            except Exception as exc:
+                last_exc = exc
+                _LOGGER.debug("OpenFAN Micro %s: get_status via %s failed: %r", self._host, p, exc)
+        assert last_exc is not None
+        raise last_exc
+
+    # ---------- OPENFAN STATUS (LED & VOLTAGE) ----------
+    async def get_openfan_status(self) -> Tuple[bool, bool]:
+        """Return (led_enabled, is_12v) from /api/v0/openfan/status."""
+        data = await self._get_json("/api/v0/openfan/status")
+        if str(data.get("status", "ok")).lower() not in ("ok", "success"):
+            raise RuntimeError(f"API status != ok: {data.get('message')}")
+        d = data.get("data", {}) or {}
+        led = str(d.get("act_led_enabled", "false")).lower() in ("true", "1", "yes", "on")
+        is_12v = str(d.get("fan_is_12v", "false")).lower() in ("true", "1", "yes", "on")
+        return led, is_12v
+
+    async def led_set(self, enabled: bool) -> dict:
+        """Enable/disable activity LED via official endpoints."""
+        path = "/api/v0/led/enable" if enabled else "/api/v0/led/disable"
+        return await self._get_json(path)
+
+    async def set_voltage_12v(self, enabled: bool) -> dict:
+        """Switch fan supply to 12V (True) or 5V (False). Requires confirm=true."""
+        path = "/api/v0/fan/voltage/high?confirm=true" if enabled else "/api/v0/fan/voltage/low?confirm=true"
+        return await self._get_json(path)

--- a/binary_sensor.py
+++ b/binary_sensor.py
@@ -1,0 +1,44 @@
+"""Stall detector binary sensor."""
+from __future__ import annotations
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add: AddEntitiesCallback) -> None:
+    dev = getattr(entry, "runtime_data", None)
+    if dev is None:
+        _LOGGER.error("OpenFAN Micro: runtime_data is None (binary_sensor)")
+        return
+    async_add([OpenFanStallBinarySensor(dev)])
+
+
+class OpenFanStallBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    _attr_icon = "mdi:alert"
+
+    def __init__(self, device) -> None:
+        super().__init__(device.coordinator)
+        self._device = device
+        self._host = getattr(device, "host", "unknown")
+        self._attr_unique_id = f"openfan_micro_stall_{self._host}"
+        self._attr_name = f"{getattr(device, 'name', 'OpenFAN Micro')} Stall"
+
+    @property
+    def is_on(self) -> bool | None:
+        data = self.coordinator.data or {}
+        return bool(data.get("stalled", False))
+
+    @property
+    def available(self) -> bool:
+        base = super().available
+        forced = getattr(self.coordinator, "_forced_unavailable", False)
+        return base and not forced
+
+    @property
+    def device_info(self):
+        return self._device.device_info()

--- a/const.py
+++ b/const.py
@@ -1,0 +1,1 @@
+DOMAIN = "openfan_micro"

--- a/coordinator.py
+++ b/coordinator.py
@@ -1,0 +1,75 @@
+"""Coordinator with availability gating and stall detection."""
+from __future__ import annotations
+import logging
+from datetime import timedelta
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .api import OpenFanApi
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class OpenFanCoordinator(DataUpdateCoordinator[dict]):
+    """Poll device: RPM/PWM + LED + 12V, and track failures & stall."""
+
+    def __init__(self, hass: HomeAssistant, api: OpenFanApi) -> None:
+        interval = int(getattr(api, "_poll_interval", 5))
+        super().__init__(hass, _LOGGER, name="OpenFAN Micro",
+                         update_interval=timedelta(seconds=interval))
+        self.api = api
+        self._consecutive_failures = 0
+        self._forced_unavailable = False
+        self._consecutive_stall = 0
+        self._notified_stall = False
+        self._last_error: str | None = None
+
+    async def _async_update_data(self) -> dict:
+        try:
+            rpm, pwm = await self.api.get_status()
+            self._consecutive_failures = 0
+            self._forced_unavailable = False
+            self._last_error = None
+
+            led, is_12v = False, False
+            try:
+                led, is_12v = await self.api.get_openfan_status()
+            except Exception as sub_err:
+                _LOGGER.debug("OpenFAN Micro: openfan/status fetch failed: %r", sub_err)
+
+            # Stall detection
+            min_pwm = int(getattr(self.api, "_min_pwm", 0) or 0)
+            need = int(getattr(self.api, "_stall_consecutive", 3) or 3)
+            stalled_now = (pwm > max(0, min_pwm)) and int(rpm) == 0
+            self._consecutive_stall = (self._consecutive_stall + 1) if stalled_now else 0
+            stalled_flag = self._consecutive_stall >= need
+            if stalled_flag and not self._notified_stall:
+                self._notified_stall = True
+                self.hass.bus.async_fire("openfan_micro_stall", {"host": getattr(self.api, "_host", "?")})
+                self.hass.components.persistent_notification.async_create(
+                    f"Fan looks stalled on {getattr(self.api, '_host', '?')} (PWM={pwm}%, RPM=0)",
+                    title="OpenFAN Micro",
+                    notification_id=f"openfan_micro_stall_{getattr(self.api,'_host','?')}",
+                )
+            if not stalled_flag:
+                self._notified_stall = False
+
+            data = {
+                "rpm": int(max(0, rpm)),
+                "pwm": int(max(0, min(100, pwm))),
+                "led": bool(led),
+                "is_12v": bool(is_12v),
+                "stalled": stalled_flag,
+            }
+            _LOGGER.debug("OpenFAN Micro update OK (%s): %s", getattr(self.api, "_host", "?"), data)
+            return data
+        except Exception as err:
+            # Availability gating after N consecutive failures
+            self._last_error = str(err)
+            self._consecutive_failures += 1
+            fail_thresh = int(getattr(self.api, "_failure_threshold", 3) or 3)
+            if self._consecutive_failures >= fail_thresh:
+                self._forced_unavailable = True
+            _LOGGER.error("OpenFAN Micro update failed (%s): %r", getattr(self.api, "_host", "?"), err)
+            raise UpdateFailed(f"Failed to update OpenFAN Micro: {err}") from err

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -1,0 +1,42 @@
+"""Diagnostics (Download diagnostics) for OpenFAN Micro."""
+from __future__ import annotations
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+REDACT = {"host"}
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    dev = getattr(entry, "runtime_data", None)
+    coord = getattr(dev, "coordinator", None)
+
+    data = {
+        "config_entry": {
+            "title": entry.title,
+            "data": {k: ("REDACTED" if k in REDACT else v) for k, v in entry.data.items()},
+            "options": entry.options,
+            "entry_id": entry.entry_id,
+        },
+        "coordinator": {
+            "last_update_success": getattr(coord, "last_update_success", None),
+            "data": getattr(coord, "data", None),
+            "failure_count": getattr(coord, "_consecutive_failures", None),
+            "stall_count": getattr(coord, "_consecutive_stall", None),
+            "forced_unavailable": getattr(coord, "_forced_unavailable", None),
+            "last_error": getattr(coord, "_last_error", None),
+        },
+        "api_tuning": {
+            "poll_interval": getattr(dev.api, "_poll_interval", None),
+            "min_pwm": getattr(dev.api, "_min_pwm", None),
+            "stall_consecutive": getattr(dev.api, "_stall_consecutive", None),
+            "failure_threshold": getattr(dev.api, "_failure_threshold", None),
+            "temp_integrate_seconds": entry.options.get("temp_integrate_seconds"),
+            "temp_update_min_interval": entry.options.get("temp_update_min_interval"),
+            "temp_deadband_pct": entry.options.get("temp_deadband_pct"),
+            "min_pwm_calibrated": entry.options.get("min_pwm_calibrated"),
+        },
+    }
+    return data

--- a/fan.py
+++ b/fan.py
@@ -1,0 +1,83 @@
+"""Fan entity for OpenFAN Micro."""
+from __future__ import annotations
+from typing import Any, Optional
+import logging
+
+from homeassistant.components.fan import FanEntity, FanEntityFeature
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    device = getattr(entry, "runtime_data", None)
+    if device is None:
+        _LOGGER.error("OpenFAN Micro: runtime_data is None")
+        return
+    async_add_entities([OpenFanMicroFan(device)])
+
+
+class OpenFanMicroFan(CoordinatorEntity, FanEntity):
+    _attr_supported_features = (
+        FanEntityFeature.SET_SPEED | FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
+    )
+
+    def __init__(self, device) -> None:
+        super().__init__(device.coordinator)
+        self._device = device
+        self._host = getattr(device, "host", "unknown")
+        name = getattr(device, "name", None) or f"OpenFAN Micro {self._host}"
+        self._attr_name = name
+        self._attr_unique_id = f"openfan_micro_fan_{self._host}"
+        self._last_pct = 50
+
+    @property
+    def device_info(self) -> dict[str, Any] | None:
+        try:
+            return self._device.device_info()
+        except Exception:
+            return None
+
+    @property
+    def available(self) -> bool:
+        base = super().available
+        forced = getattr(self.coordinator, "_forced_unavailable", False)
+        return base and not forced
+
+    @property
+    def percentage(self) -> int | None:
+        data = self.coordinator.data or {}
+        return data.get("pwm")
+
+    @property
+    def is_on(self) -> bool | None:
+        pct = self.percentage or 0
+        return pct > 0
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        # Enforce global min_pwm if >0 (except when turning off)
+        min_pwm = int(getattr(self._device.api, "_min_pwm", 0) or 0)
+        pct = int(percentage)
+        if pct > 0:
+            pct = max(min_pwm, pct)
+        pct = max(0, min(100, pct))
+        self._last_pct = pct
+        await self._device.api.set_pwm(pct)
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_on(
+        self,
+        percentage: Optional[int] = None,
+        preset_mode: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        pct = int(percentage) if percentage is not None else (self._last_pct or 50)
+        await self.async_set_percentage(pct)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await self.async_set_percentage(0)

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "openfan_micro",
+  "name": "OpenFAN Micro",
+  "version": "0.3.1-beta.2",
+  "config_flow": true,
+  "documentation": "https://github.com/bitlisz1/hass-openfan-micro",
+  "requirements": [],
+  "codeowners": ["@BeryJu", "@bitlisz1"],
+  "iot_class": "local_polling"
+}

--- a/options_flow.py
+++ b/options_flow.py
@@ -1,0 +1,45 @@
+"""Options flow for OpenFAN Micro (polling, thresholds, temp curve + smoothing)."""
+from __future__ import annotations
+from typing import Any, Dict
+import voluptuous as vol
+from homeassistant import config_entries
+
+from .const import DOMAIN
+
+DEFAULTS = {
+    "poll_interval": 5,
+    "min_pwm": 0,
+    "temp_entity": "",
+    "temp_curve": "45=25, 65=55, 70=100",  # C=%
+    "temp_integrate_seconds": 30,
+    "temp_update_min_interval": 10,
+    "temp_deadband_pct": 3,
+    "failure_threshold": 3,
+    "stall_consecutive": 3,
+    # "min_pwm_calibrated": false
+}
+
+def _schema(options: dict):
+    return vol.Schema({
+        vol.Optional("poll_interval", default=options.get("poll_interval", DEFAULTS["poll_interval"])): vol.All(int, vol.Range(min=2, max=60)),
+        vol.Optional("min_pwm", default=options.get("min_pwm", DEFAULTS["min_pwm"])): vol.All(int, vol.Range(min=0, max=60)),
+        vol.Optional("temp_entity", default=options.get("temp_entity", DEFAULTS["temp_entity"])): str,
+        vol.Optional("temp_curve", default=options.get("temp_curve", DEFAULTS["temp_curve"])): str,
+        vol.Optional("temp_integrate_seconds", default=options.get("temp_integrate_seconds", DEFAULTS["temp_integrate_seconds"])): vol.All(int, vol.Range(min=5, max=900)),
+        vol.Optional("temp_update_min_interval", default=options.get("temp_update_min_interval", DEFAULTS["temp_update_min_interval"])): vol.All(int, vol.Range(min=2, max=300)),
+        vol.Optional("temp_deadband_pct", default=options.get("temp_deadband_pct", DEFAULTS["temp_deadband_pct"])): vol.All(int, vol.Range(min=0, max=20)),
+        vol.Optional("failure_threshold", default=options.get("failure_threshold", DEFAULTS["failure_threshold"])): vol.All(int, vol.Range(min=1, max=10)),
+        vol.Optional("stall_consecutive", default=options.get("stall_consecutive", DEFAULTS["stall_consecutive"])): vol.All(int, vol.Range(min=1, max=10)),
+    })
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    def __init__(self, entry: config_entries.ConfigEntry) -> None:
+        self.entry = entry
+
+    async def async_step_init(self, user_input: Dict[str, Any] | None = None):
+        if user_input is not None:
+            merged = dict(self.entry.options or {})
+            merged.update(user_input)
+            return self.async_create_entry(title="", data=merged)
+
+        return self.async_show_form(step_id="init", data_schema=_schema(self.entry.options or {}))

--- a/sensor.py
+++ b/sensor.py
@@ -1,0 +1,54 @@
+"""RPM sensor for OpenFAN Micro."""
+from __future__ import annotations
+from typing import Any
+import logging
+
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    device = getattr(entry, "runtime_data", None)
+    if device is None:
+        _LOGGER.error("OpenFAN Micro: runtime_data is None (sensor)")
+        return
+    async_add_entities([OpenFanRpmSensor(device)])
+
+
+class OpenFanRpmSensor(CoordinatorEntity, SensorEntity):
+    _attr_native_unit_of_measurement = "rpm"
+    _attr_icon = "mdi:fan"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, device) -> None:
+        super().__init__(device.coordinator)
+        self._device = device
+        self._host = getattr(device, "host", "unknown")
+        name = getattr(device, "name", None) or f"OpenFAN Micro {self._host}"
+        self._attr_name = f"{name} RPM"
+        self._attr_unique_id = f"openfan_micro_rpm_{self._host}"
+
+    @property
+    def device_info(self) -> dict[str, Any] | None:
+        try:
+            return self._device.device_info()
+        except Exception:
+            return None
+
+    @property
+    def available(self) -> bool:
+        base = super().available
+        forced = getattr(self.coordinator, "_forced_unavailable", False)
+        return base and not forced
+
+    @property
+    def native_value(self) -> int | None:
+        data = self.coordinator.data or {}
+        return int(data.get("rpm") or 0)

--- a/services.yaml
+++ b/services.yaml
@@ -1,0 +1,49 @@
+led_set:
+  name: LED set
+  description: Turn the device status LED on or off (if supported by firmware).
+  fields:
+    entity_id:
+      required: true
+      selector: { entity: { domain: fan } }
+    enabled:
+      required: true
+      selector: { boolean: {} }
+
+set_voltage:
+  name: Set fan supply voltage
+  description: Switch 5V/12V if the firmware supports it.
+  fields:
+    entity_id:
+      required: true
+      selector: { entity: { domain: fan } }
+    volts:
+      required: true
+      selector: { select: { options: [5, 12] } }
+
+calibrate_min:
+  name: Calibrate minimum PWM
+  description: Sweep PWM and detect minimum that reliably spins the fan; stores result in options as min_pwm and marks calibrated.
+  fields:
+    entity_id:
+      required: true
+      selector: { entity: { domain: fan } }
+    from_pct:
+      required: false
+      default: 10
+      selector: { number: { min: 0, max: 50, step: 1, mode: box } }
+    to_pct:
+      required: false
+      default: 40
+      selector: { number: { min: 20, max: 60, step: 1, mode: box } }
+    step:
+      required: false
+      default: 5
+      selector: { number: { min: 1, max: 20, step: 1, mode: box } }
+    rpm_threshold:
+      required: false
+      default: 100
+      selector: { number: { min: 0, max: 1000, step: 10, mode: box } }
+    margin:
+      required: false
+      default: 5
+      selector: { number: { min: 0, max: 20, step: 1, mode: box } }

--- a/switch.py
+++ b/switch.py
@@ -1,0 +1,86 @@
+"""LED and 12V switches for OpenFAN Micro."""
+from __future__ import annotations
+from typing import Any
+import logging
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
+    device = getattr(entry, "runtime_data", None)
+    if device is None:
+        _LOGGER.error("OpenFAN Micro: runtime_data is None (switch)")
+        return
+    async_add_entities([OpenFanLedSwitch(device), OpenFanVoltageSwitch(device)])
+
+
+class _BaseSwitch(CoordinatorEntity, SwitchEntity):
+    def __init__(self, device) -> None:
+        super().__init__(device.coordinator)
+        self._device = device
+        self._host = getattr(device, "host", "unknown")
+
+    @property
+    def device_info(self) -> dict[str, Any] | None:
+        try:
+            return self._device.device_info()
+        except Exception:
+            return None
+
+    @property
+    def available(self) -> bool:
+        base = super().available
+        forced = getattr(self.coordinator, "_forced_unavailable", False)
+        return base and not forced
+
+
+class OpenFanLedSwitch(_BaseSwitch):
+    """Activity LED on/off."""
+    _attr_icon = "mdi:led-on"
+
+    def __init__(self, device) -> None:
+        super().__init__(device)
+        self._attr_name = f"{getattr(device, 'name', 'OpenFAN Micro')} LED"
+        self._attr_unique_id = f"openfan_micro_led_{self._host}"
+
+    @property
+    def is_on(self) -> bool | None:
+        data = self.coordinator.data or {}
+        return bool(data.get("led"))
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        await self._device.api.led_set(True)
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await self._device.api.led_set(False)
+        await self.coordinator.async_request_refresh()
+
+
+class OpenFanVoltageSwitch(_BaseSwitch):
+    """12V mode on/off (on=12V, off=5V)."""
+    _attr_icon = "mdi:flash"
+
+    def __init__(self, device) -> None:
+        super().__init__(device)
+        self._attr_name = f"{getattr(device, 'name', 'OpenFAN Micro')} 12V Mode"
+        self._attr_unique_id = f"openfan_micro_12v_{self._host}"
+
+    @property
+    def is_on(self) -> bool | None:
+        data = self.coordinator.data or {}
+        return bool(data.get("is_12v"))
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        await self._device.api.set_voltage_12v(True)
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await self._device.api.set_voltage_12v(False)
+        await self.coordinator.async_request_refresh()

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,0 +1,18 @@
+{
+  "title": "OpenFAN Micro",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Add OpenFAN Micro",
+        "description": "Enter the IP address of your device.",
+        "data": {
+          "host": "Host (IP address)",
+          "name": "Name (optional)"
+        }
+      }
+    },
+    "error": {
+      "unknown": "Unknown error"
+    }
+  }
+}


### PR DESCRIPTION
Summary
This PR adds the full “pro” feature set to the OpenFAN Micro integration:

LED switch (switch._led)
12V mode switch (switch._12v_mode) — on=12V, off=5V
Availability gating — entities turn unavailable only after N consecutive failures
Stall detection — binary sensor + persistent notification + openfan_micro_stall event
Temperature-based control — piecewise-linear curve (e.g. 45=25, 65=55, 70=100)
Smoothing / rate-limiting for temperature control
- temp_integrate_seconds — moving average window
- temp_update_min_interval — minimum time between PWM changes
- temp_deadband_pct — only change when difference exceeds this
Calibration service — finds a reliable min_pwm and enables temp control
Temperature control is gated by calibration: it only runs if min_pwm_calibrated: true and min_pwm > 0, and it never drives below the configured minimum (except turning fully off → 0%).
Implementation notes
New/updated files in custom_components/openfan_micro/:
- init.py — temp controller + smoothing, services, options hookup
- api.py — official LED & voltage endpoints, status parsing
- coordinator.py — RPM/PWM + LED + 12V + stall & availability counters
- fan.py, sensor.py — min-PWM enforcement, RPM sensor
- switch.py — LED / 12V switches
- binary_sensor.py — stall indicator
- options_flow.py — new options (smoothing, thresholds)
- diagnostics.py — “Download diagnostics”
- services.yaml — HA service schemas
- manifest.json — version: 0.3.1-beta.2
- translations/en.json

README updated with setup, examples, and troubleshooting.
Optional hacs.json included to render README in HACS and avoid complaints.
Testing checklist

Fan on/off/percentage still works; RPM sensor updates.
LED switch toggles the device LED; state reflects after refresh.
12V switch flips supply; /api/v0/openfan/status reports fan_is_12v correctly.
Temp controller:
Does nothing before calibration.
After calibrate_min, follows the configured curve, respects min-PWM.
Smoothing works: average window, min interval, and deadband prevent flapping.
Stall detection:
With PWM above min and RPM holding 0 for N cycles ⇒ stall sensor = on, notification + event.
Availability: only after the configured number of consecutive failures do entities become unavailable.
Backward compatibility

No breaking changes expected for existing setups. New entities (LED/12V/stall) are additive.
Versioning

Tag as pre-release: v0.3.1-beta.2 so HACS beta users can test safely.